### PR TITLE
Permissive more-itertools requirements

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "requests~=2.31",
   "validators~=0.21",
   "pandas~=2.0",
-  "more-itertools~=10.1",
+  "more-itertools>=8,<=10.1",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "starpoint"
-version = "0.6.0"
+version = "0.6.1"
 authors = [{ name = "pointable", email = "package-maintainers@pointable.ai" }]
 description = "SDK for Starpoint DB"
 readme = "README.md"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -259,6 +259,10 @@ idna==3.4 \
     # via
     #   requests
     #   yarl
+more-itertools==10.1.0 \
+    --hash=sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a \
+    --hash=sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6
+    # via starpoint (pyproject.toml)
 multidict==6.0.4 \
     --hash=sha256:01a3a55bd90018c9c080fbb0b9f4891db37d148a0a18722b42f94694f8b6d4c9 \
     --hash=sha256:0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8 \


### PR DESCRIPTION
We want to be a bit more permissive since there are many tools out there that specify other versions of more-itertools, and we don't really care to lock things out on our end.